### PR TITLE
fixed division error during sass compilation

### DIFF
--- a/src/react/package.json
+++ b/src/react/package.json
@@ -9,10 +9,10 @@
     "ag-grid-community": "latest",
     "ag-grid-enterprise": "latest",
     "ag-grid-react": "latest",
-    "node-sass": "^4.14.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-scripts": "3.4.1"
+    "react-scripts": "3.4.1",
+    "sass": "^1.39.0"
   },
   "scripts": {
     "start": "PORT=8080 react-scripts start",


### PR DESCRIPTION
Compilation error with existing `node-sass` package, which can be fixed by changing to Dart `sass` implementation. 
![image](https://user-images.githubusercontent.com/47183406/132620262-fb552dba-9a80-4a2c-8397-0a63b4961474.png)

